### PR TITLE
Custom Gradient Support

### DIFF
--- a/Sources/Shimmer/Shimmer.swift
+++ b/Sources/Shimmer/Shimmer.swift
@@ -189,7 +189,7 @@ public extension View {
                     }
                     .frame(maxWidth: 200)
                     .shimmering(gradientMask: .init(
-                        inverse: false,
+                        inverse: true,
                         centerOpacity: 0.8,
                         edgeOpacity: 0.3,
                         startPoint: .topLeading,

--- a/Sources/Shimmer/Shimmer.swift
+++ b/Sources/Shimmer/Shimmer.swift
@@ -20,33 +20,15 @@ public struct Shimmer: ViewModifier {
     private let gradientMask: GradientMask
     
     /// Initializes his modifier with a custom animation,
-    /// - Parameter animation: A custom animation. The default animation is
-    ///   `.linear(duration: 1.5).repeatForever(autoreverses: false)`.
+    /// - Parameters:
+    ///   - animation: Animation used to move the linear gradient.
+    ///   - gradientMask: `GradientMask` object used to define the linear gradient.
     init(
         animation: Animation,
         gradientMask: GradientMask
     ) {
         self.animation = animation
         self.gradientMask = gradientMask
-    }
-    
-    /// Convenience, backward-compatible initializer.
-    /// - Parameters:
-    ///   - duration: The duration of a shimmer cycle in seconds. Default: `1.5`.
-    ///   - bounce: Whether to bounce (reverse) the animation back and forth. Defaults to `false`.
-    ///   - delay:A delay in seconds. Defaults to `0`.
-    init(
-        duration: Double,
-        bounce: Bool,
-        delay: Double,
-        gradientMask: GradientMask
-    ) {
-        self.init(
-            animation: .linear(duration: duration)
-                .repeatForever(autoreverses: bounce)
-                .delay(delay),
-            gradientMask: .init()
-        )
     }
 
     public func body(content: Content) -> some View {
@@ -132,34 +114,9 @@ public extension View {
     /// Adds an animated shimmering effect to any view, typically to show that
     /// an operation is in progress.
     /// - Parameters:
-    ///   - active: Convenience parameter to conditionally enable the effect. Defaults to `true`.
-    ///   - duration: The duration of a shimmer cycle in seconds. Default: `1.5`.
-    ///   - bounce: Whether to bounce (reverse) the animation back and forth. Defaults to `false`.
-    ///   - delay:A delay in seconds. Defaults to `0`.
-    @ViewBuilder func shimmering(
-        active: Bool = true,
-        duration: Double = 1.5,
-        bounce: Bool = false,
-        delay: Double = 0,
-        gradientMask: Shimmer.GradientMask = .init()
-    ) -> some View {
-        if active {
-            modifier(Shimmer(
-                duration: duration,
-                bounce: bounce,
-                delay: delay,
-                gradientMask: gradientMask))
-        } else {
-            self
-        }
-    }
-
-    // Adds an animated shimmering effect to any view, typically to show that
-    /// an operation is in progress.
-    /// - Parameters:
-    ///   - active: Convenience parameter to conditionally enable the effect. Defaults to `true`.
-    ///   - animation: A custom animation. The default animation is
-    ///   `.linear(duration: 1.5).repeatForever(autoreverses: false)`.
+    ///   - active: Convenience parameter to conditionally enable the effect.
+    ///   - animation: Animation used to move the linear gradient.
+    ///   - gradientMask: `GradientMask` object used to define the linear gradient.
     @ViewBuilder
     func shimmering(
         active: Bool = true,
@@ -171,6 +128,29 @@ public extension View {
         } else {
             self
         }
+    }
+    
+    /// Adds an animated shimmering effect to any view, typically to show that
+    /// an operation is in progress.
+    /// - Parameters:
+    ///   - active: Convenience parameter to conditionally enable the effect.
+    ///   - duration: The duration of a shimmer cycle in seconds.
+    ///   - bounce: Whether to bounce (reverse) the animation back and forth.
+    ///   - delay:A delay in seconds.
+    ///   - gradientMask: `GradientMask` object used to define the linear gradient.
+    @ViewBuilder func shimmering(
+        active: Bool = true,
+        duration: Double = 1.5,
+        bounce: Bool = false,
+        delay: Double = 0,
+        gradientMask: Shimmer.GradientMask = .init()
+    ) -> some View {
+        self.shimmering(
+            active: active,
+            animation: .linear(duration: duration)
+                .repeatForever(autoreverses: bounce)
+                .delay(delay),
+            gradientMask: gradientMask)
     }
 }
 

--- a/Sources/Shimmer/ViewExtensions.swift
+++ b/Sources/Shimmer/ViewExtensions.swift
@@ -1,0 +1,30 @@
+//
+//  ViewExtensions.swift
+//
+//  Created by Ethan Pippin on 11/10/22.
+//
+
+import SwiftUI
+
+extension View {
+    
+    @ViewBuilder
+    func inverseMask<M: View>(_ mask: M) -> some View {
+        let inversed = mask
+            .foregroundColor(.black)
+            .background(Color.white)
+            .compositingGroup()
+            .luminanceToAlpha()
+        
+        self.mask(inversed)
+    }
+    
+    @ViewBuilder
+    func mask<M: View>(_ mask: M, inverse: Bool) -> some View {
+        if inverse {
+            self.inverseMask(mask)
+        } else {
+            self.mask(mask)
+        }
+    }
+}


### PR DESCRIPTION
Hello there 👋 

I'm going to be using a shimmer in my application and thought this package was great! However, I desired more customization over the gradient.

## Overview

I change `GradientMask` to supply the definition used for the underlying `LinearGradient`. The default values match the current gradient.

<details>
<summary>Example</summary>

```swift
Text("Shimmering")
	.shimmering(gradientMask: .init(
		centerOpacity: 0.8,
		edgeOpacity: 0.3,
		startPoint: .topLeading,
		endPoint: .bottomTrailing,
		width: 0.1))
```
</details>

Since `GradientMask.startPoint` and `GradientMask.endPoint` are properties, this allows the gradient to "move" in different directions. Due to this, I think that this overrides #4.

<details>
<summary>Right to Left Example</summary>

https://user-images.githubusercontent.com/20747774/201496531-581444e8-5d9e-4204-82bf-802ce0ec05ee.mov
</details>

<details>
<summary>Top to Bottom Example</summary>

https://user-images.githubusercontent.com/20747774/201496550-99f90a1a-9c99-4b07-ab97-d48116244210.mov
</details>

## Inverse mask

Currently, the gradient is applied as a plain `.mask(...)` which doesn't suite my needs, as it changes the opacity of the underlying view to the opacity of the edge points of the `LinearGradient`, and I don't think that a shimmer should change the opacity of the underlying view. `GradientMask.inverse` determines whether the mask should be inverted or not, therefore having the shimmer effect be the gradient itself, and not a mask over the gradient. I personally think this should be the default behavior but I won't change the current implementation.

<details>
<summary>Current Implementation Example</summary>

https://user-images.githubusercontent.com/20747774/201496252-16c66f36-68ee-4034-8ad5-6b414892965d.mov
</details>

<details>
<summary>Inverted Mask Example</summary>

https://user-images.githubusercontent.com/20747774/201496481-64b57e6b-e59d-4c8b-b9b9-ba7528bebda1.mov
</details>

## Other

- I provide two view functions used to determine the mask
- Remove the defaults to the `Shimmer` object. Redundant for this package's use.
- Some personal linting styles applied
- Previews are updated to show `GradientMask` customization
- Update documentation. The phrases where the default was provided was redundant as they are already shown in the Xcode preview while you are reading them.