### PR TITLE
fix: Remove IfElse To Keep State Correct

### DIFF
--- a/Sources/Shimmer/Utility/Gradient+Convenience.swift
+++ b/Sources/Shimmer/Utility/Gradient+Convenience.swift
@@ -1,0 +1,14 @@
+//
+//  Gradient+Convenience.swift
+//
+//
+//  Created by Vladyslav Sosiuk on 06.11.2023.
+//
+
+import SwiftUI
+
+extension Gradient {
+    static var transparent: Self {
+        .init(colors: [.black]) // .black has no effect
+    }
+}

--- a/Sources/Shimmer/Utility/View+iOS13Support.swift
+++ b/Sources/Shimmer/Utility/View+iOS13Support.swift
@@ -1,0 +1,22 @@
+//
+//  View+iOS13Support.swift
+//
+//
+//  Created by Vladyslav Sosiuk on 06.11.2023.
+//
+
+import SwiftUI
+import Combine
+
+extension View {
+    /// A backwards compatible wrapper for iOS 14 `onChange` based on https://betterprogramming.pub/implementing-swiftui-onchange-support-for-ios13-577f9c086c9
+    @ViewBuilder func valueChanged<T: Equatable>(value: T, onChange: @escaping (T) -> Void) -> some View {
+        if #available(iOS 14.0, *) {
+            self.onChange(of: value, perform: onChange)
+        } else {
+            self.onReceive(Just(value)) { (value) in
+                onChange(value)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Refs: #12

This PR addresses the SwiftUI identification issue. When a view to which the shimmering modifier is applied has its own state and toggles between shimmering active true or false the view would lose its state. Here's a video representing the issue: 

https://github.com/markiv/SwiftUI-Shimmer/assets/24592433/d9502996-7b56-4c16-87e0-a145debef83a

Here is a video with the expected behavior:

https://github.com/markiv/SwiftUI-Shimmer/assets/24592433/75e6ca78-36e0-4eff-91f1-a0ab2f05f80b

why is this an issue described in the following article: 
https://www.objc.io/blog/2021/08/24/conditional-view-modifiers/