### PR TITLE
Prevent shimmer animation from affecting initial layout of the view

### DIFF
--- a/Sources/Shimmer/Shimmer.swift
+++ b/Sources/Shimmer/Shimmer.swift
@@ -82,7 +82,6 @@ public struct Shimmer: ViewModifier {
 
     public func body(content: Content) -> some View {
         content
-            .animation(nil, value: false) // Prevent animation from propagating to the modified view
             .mask(LinearGradient(gradient: gradient, startPoint: startPoint, endPoint: endPoint))
             .animation(animation, value: isInitialState)
             .onAppear {

--- a/Sources/Shimmer/Shimmer.swift
+++ b/Sources/Shimmer/Shimmer.swift
@@ -82,10 +82,15 @@ public struct Shimmer: ViewModifier {
 
     public func body(content: Content) -> some View {
         content
+            .animation(nil, value: false) // Prevent animation from propagating to the modified view
             .mask(LinearGradient(gradient: gradient, startPoint: startPoint, endPoint: endPoint))
             .animation(animation, value: isInitialState)
             .onAppear {
-                isInitialState = false
+                // Delay the animation until the initial layout is established
+                // to prevent animating the appearance of the view
+                DispatchQueue.main.asyncAfter(deadline: .now()) {
+                    isInitialState = false
+                }
             }
     }
 }


### PR DESCRIPTION
This introduces two changes:
1. Prevents the shimmer animation from propagating to the modified view
2. Delays the initial animation until the layout of the view is established so that the initial appearance of the view is not animated.

Fixes #19 